### PR TITLE
Adding Teams Controller

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,0 +1,75 @@
+class TeamsController < ApplicationController
+  before_action :set_team, only: [:show, :edit, :update, :destroy]
+
+  # GET /users
+  # GET /users.json
+
+  def index
+    @teams = Team.all.where(active: true)
+  end
+
+  # GET /users/1
+  # GET /users/1.json
+  def show
+  end
+
+  # GET /users/new
+  def new
+    @team = Team.new
+  end
+
+  # GET /users/1/edit
+  def edit
+  end
+
+  # POST /users
+  # POST /users.json
+  def create
+    @team = Team.new(user_params)
+
+    respond_to do |format|
+      if @team.save
+        format.html { redirect_to @team, notice: 'Team was successfully created.' }
+        format.json { render :show, status: :created, location: @team }
+      else
+        format.html { render :new }
+        format.json { render json: @team.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /users/1
+  # PATCH/PUT /users/1.json
+  def update
+    respond_to do |format|
+      if @team.update(team_params)
+        format.html { redirect_to @team, notice: 'Team was successfully updated.' }
+        format.json { render :show, status: :ok, location: @team }
+      else
+        format.html { render :edit }
+        format.json { render json: @team.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /users/1
+  # DELETE /users/1.json
+  def destroy
+    @team.destroy
+    respond_to do |format|
+      format.html { redirect_to users_url, notice: 'Team was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_team
+      @team = Team.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def team_params
+      params.require(:team).permit(:name, :description, :active, :is_parent, :parent_team_id, :manager_id)
+    end
+end


### PR DESCRIPTION
Purpose: Adding a base Teams Controller Structure

Notes: While this controller has code for basic crud operations, these are simply copy/pasted from an old controller and many changes will be needed down the road.