### PR TITLE
Fixing some Team Validations - Updated boolean validations to allow b…

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -6,11 +6,9 @@ class Team < ApplicationRecord
 
   validates :name, presence: true
   validates :name, length: { minimum: 2 }
-  validates :active, presence: true
-  validates :is_parent, presence: true
+  validates :active, inclusion: { in: [ true, false ] }
+  validates :is_parent, inclusion: { in: [ true, false ] }
 
   validates_associated :manager
-  validates :parent_team, presence: true
-
 
 end


### PR DESCRIPTION
I realized the boolean validations checking for 'presence: true' meant it would not accept blank entries (or false)

Updated to include true/false.

Also removed the parent_team presence validation so I can test making teams without parents, will add back later if we decide it is needed.