### PR TITLE
Fixing User Validations, updated boolean to accept blank as false. Re…

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,11 +9,10 @@ class User < ApplicationRecord
   validates :last_name, length: { minimum: 2 }
   validates :title, presence: true
   validates :title, length: { minimum: 2 }
-  validates :is_manager, presence: true
-  validates :active, presence: true
+  validates :is_manager, inclusion: { in: [ true, false ] }
+  validates :active, inclusion: { in: [ true, false ] }
 
   validates_associated :users
-  validates :manager, presence: true
   validates :team, presence: true
 
 end


### PR DESCRIPTION
I realized the boolean validations checking for 'presence: true' meant it would not accept blank entries (or false)

Updated to include true/false.

Also removed the manager presence validation so I can test making users without managers, will add back later if we decide it is needed.