### PR TITLE
Removed the active checkbox from both Teams/Users _form.html.erb, mad…

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -26,6 +26,7 @@ class TeamsController < ApplicationController
   # POST /users.json
   def create
     @team = Team.new(team_params)
+    @team.active = true
 
     respond_to do |format|
       if @team.save

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -27,6 +27,7 @@ class UsersController < ApplicationController
   # POST /users.json
   def create
     @user = User.new(user_params)
+    @user.active = true
 
     respond_to do |format|
       if @user.save

--- a/app/views/teams/_form.html.erb
+++ b/app/views/teams/_form.html.erb
@@ -27,11 +27,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :active %>
-    <%= form.check_box :active %>
-  </div>
-
-  <div class="field">
     <%= form.label :parent_team_id %>
     <%= form.number_field :parent_team_id %>
   </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -57,11 +57,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :active %>
-    <%= form.check_box :active %>
-  </div>
-
-  <div class="field">
     <%= form.label :manager_id %>
     <%= form.number_field :manager_id %>
   </div>


### PR DESCRIPTION
When creating a Team or User we can assume they are active=true by default. Therefore, removed that checkbox from the _form.html.erb and added active=true to the create function in the controllers.

Will later need to add the option to "deactivate" Teams and Users, but this will allow us to remove "destroy" capabilities from the app.