### PR TITLE
Adding an ALL Users Index to the landing welcome page, along with the…

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
   # GET /users.json
 
   def index
-    @users = User.all.where(active: true)
+    @users = User.all.where(active: true).where(team_id: params[:team_id])
   end
 
   # GET /users/1

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,34 @@
 class WelcomeController < ApplicationController
   def index
   end
+
+  def users
+    @users = User.all.where(active: true)
+  end
+
+  def new_user
+    @user = User.new
+  end
+
+  def create_new_user
+    @user = User.new(user_params)
+    @user.active = true
+
+    respond_to do |format|
+      if @user.save
+        format.html { redirect_to users_path, notice: 'User was successfully created.' }
+        format.json { render :show, status: :created, location: @user }
+      else
+        format.html { render :new }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :title, :tier, :team_id, :email, :slack, :bio, :is_manager, :active, :manager_id, :started_at)
+  end
+
 end

--- a/app/views/welcome/_form.html.erb
+++ b/app/views/welcome/_form.html.erb
@@ -1,0 +1,72 @@
+<%= form_with(model: [@team, @user], local: true) do |form| %>
+  <% if user.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(user.errors.count, "error") %> prohibited this user from being saved:</h2>
+
+      <ul>
+      <% user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :first_name %>
+    <%= form.text_field :first_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :last_name %>
+    <%= form.text_field :last_name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div class="field">
+    <%= form.label :tier %>
+    <%= form.number_field :tier %>
+  </div>
+
+  <div class="field">
+    <%= form.label :team_id %>
+    <%= form.number_field :team_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :email %>
+    <%= form.text_field :email %>
+  </div>
+
+  <div class="field">
+    <%= form.label :slack %>
+    <%= form.text_field :slack %>
+  </div>
+
+  <div class="field">
+    <%= form.label :bio %>
+    <%= form.text_field :bio %>
+  </div>
+
+  <div class="field">
+    <%= form.label :is_manager %>
+    <%= form.check_box :is_manager %>
+  </div>
+
+  <div class="field">
+    <%= form.label :manager_id %>
+    <%= form.number_field :manager_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :started_at %>
+    <%= form.date_field :started_at %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/welcome/new_user.html.erb
+++ b/app/views/welcome/new_user.html.erb
@@ -1,0 +1,5 @@
+<h1>New User</h1>
+
+<%= render 'form', user: @user %>
+
+<%= link_to 'Back', users_path %>

--- a/app/views/welcome/users.html.erb
+++ b/app/views/welcome/users.html.erb
@@ -1,12 +1,13 @@
 <p id="notice"><%= notice %></p>
 
-<h1><%= @team.name %> Users</h1>
+<h1>Users</h1>
 
 <table>
   <thead>
     <tr>
       <th>First Name</th>
       <th>Last Name</th>
+      <th>Team</th>
       <th>Title</th>
       <th>Tier</th>
       <th>Email</th>
@@ -16,15 +17,17 @@
       <th>Active?</th>
       <th>Manager_id</th>
       <th>Started At</th>
-      <th colspan="14"></th>
+      <th colspan="15"></th>
     </tr>
   </thead>
 
   <tbody>
     <% @users.each do |user| %>
+    <% @team = Team.find(user.team_id) %>
       <tr>
         <td><%= user.first_name %></td>
         <td><%= user.last_name %></td>
+        <td><%= user.team_id %></td>
         <td><%= user.title %></td>
         <td><%= user.tier %></td>
         <td><%= user.email %></td>
@@ -45,4 +48,4 @@
 
 <%= link_to 'Home', root_path %>
 <%= link_to 'Teams', teams_path %>
-<%= link_to 'New User', new_team_user_path %>
+<%= link_to 'New User', new_user_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
   root 'welcome#index'
   resources :welcome, only: [:index]
+  get '/users', to: 'welcome#users', as: 'users'
+  get '/new_user', to: 'welcome#new_user', as: 'new_user'
+  post '/users', to: 'welcome#create_new_user', as: 'create_new_user'
   resources :teams, :except => [:delete] do
     get '/deactivate', to: 'teams#deactivate', as: 'deactivate'
     resources :users, :except => [:delete] do


### PR DESCRIPTION
Added a all Users Index from the welcome landing page, so we will be able to see a list of all users that are not users nested into a specific team. This required some new routes, controller actions, and views for 'welcome'.

This highlighted a few other issues:

- Current nested users controller was still showing all users, filtered to only show users with that team id (updated in this commit)
- Users form still asks for a team_id input. When adding a new user from the welcome users index, a team_id should still be prompted. However when adding a new user from a team users index this should be removed and the team automatically assigned (not updated in this commit - will update later)