### PR TITLE
Updating the users_controller

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     @user.active = true
+    @user.team_id = @team.id
 
     respond_to do |format|
       if @user.save

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -32,11 +32,6 @@
   </div>
 
   <div class="field">
-    <%= form.label :team_id %>
-    <%= form.number_field :team_id %>
-  </div>
-
-  <div class="field">
     <%= form.label :email %>
     <%= form.text_field :email %>
   </div>


### PR DESCRIPTION
The users_controller to auto-assign the team_id when creating a user from the Team page. Team still needs to be manually assigned when assigning from the All Users index